### PR TITLE
Make next-team a code owner for package files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,7 @@
 
 # Allow next-team to approve PRs that only modify package files
 **/package*.json @next-team @Financial-Times/cp-reliability
+
+
+# Allow next-team to approve PRs that only modify package files
+**/package*.json @next-team @Financial-Times/cp-reliability


### PR DESCRIPTION
This adds @next-team as a code owner for `package.json` and `package-lock.json` files in the repo. This is the last step required to enable [auto-merging of Dependency PRs](https://github.com/Financial-Times/dependency-auto-merger).