### PR TITLE
chore: change the Dependabot versioning strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,7 @@ version: 2
 updates:
 
   - package-ecosystem: "npm"
+    versioning-strategy: "increase"
     directory: "/"
     schedule:
       interval: "daily"


### PR DESCRIPTION
For some reason this repo likes to only update package-lock files. Stack overflow tells me that being explicit about the [versioning strategy](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--) will resolve this.